### PR TITLE
Fixed file structure in zip archive 

### DIFF
--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -73,7 +73,7 @@ def main() -> None:
 
             if info != b"":
                 item = zipfile.ZipInfo()
-                item.filename = os.path.join(basename, filename)
+                item.filename = basename + "/" + filename
                 item.external_attr = 0o100644 << 16
                 item.compress_type = zipfile.ZIP_DEFLATED
                 timestamp, commit_hash = info.split(b":")


### PR DESCRIPTION
closes #219 

I was having the same issue in MacOS 14.3. 

The issue he was experiencing is likely due to the way the file paths are being handled when adding files to the zip archive. In the script, the file paths are being joined using `os.path.join(basename, filename)`. This line of code is creating a string that represents the path to the file, with the `basename` and the `filename` separated by a slash or a backslash, depending on the operating system.

However, when the zip file is being extracted, the entire string (including the slash or backslash) is being treated as the filename, rather than as a directory structure. This is why he was seeing files named "building_tools\__init__.py" instead of a directory named "building_tools" with a file named "__init__.py" inside it.

How it was extracted originally:

![image](https://github.com/ranjian0/building_tools/assets/29440338/770856d7-836c-4ac2-98c9-7595d11df6eb)


How it is supposed to be:

![image](https://github.com/ranjian0/building_tools/assets/29440338/bdc73d42-b272-4ba8-9473-d6e7c564a154)


To fix this issue, I replaced the `os.path.join` function with a simple string concatenation, and to always use a forward slash (`/`) to separate the directory and the filename. This should ensure that the zip file is created with the correct directory structure, regardless of the operating system.

This change should ensure that the `building_tools` directory is created correctly when the zip file is extracted.
